### PR TITLE
Fix highlight banner alignment on smaller viewports

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1402,7 +1402,7 @@
 	@media screen and (max-width: 480px) {
 
 		html, body {
-			min-width: 320px;
+			min-width: 480px;
 		}
 
 	}
@@ -3642,12 +3642,12 @@
 				.wrapper.cta > .inner > * {
 					padding-left: 1.5em;
 					-ms-flex: auto;
-					width: 50%;
+					/*width: 50%;*/
 				}
 
 				.wrapper.cta > .inner > :first-child {
 					padding-left: 0;
-					width: 50%;
+					/*width: 50%;*/
 				}
 
 			body.is-mobile .wrapper.cta {
@@ -3848,6 +3848,7 @@
 		position: fixed;
 		top: 0;
 		width: 100%;
+		min-width: 480px;
 		z-index: 10000;
 	}
 
@@ -4744,6 +4745,10 @@ ul.sponsors{
 
 /*-----TEAM ROSTER-----*/
 
+.team-lead{
+	display:flex;
+}
+
 .team-lead li{
 	width: 12em;
 	margin: 0em 2em;
@@ -4755,7 +4760,6 @@ ul.sponsors{
 	text-align: center;
 	background: transparent;
 	color:#EEEEEE;
-	float: right;
 }
 
 	.team-lead li:first-child{
@@ -4838,16 +4842,15 @@ ul.sponsors{
 			color: rgba(47,55,63, 0.8);
 		}
 
-.wrapper.cta > .inner > .inner-col-align {
-	width: 100%;
+.wrapper.cta > .inner > :first-child {
+	flex: 1 1 auto;
 }
 
-	.wrapper.cta > .inner > .inner-col-align ul{
-		width: 100%;
-		display: flex;
-		justify-content: space-between;
-	}
+.wrapper.cta > .inner > ul.team-lead {
+	flex: 0 0 auto;
+	display: flex;
+}
 
-		.wrapper.cta > .inner > .inner-col-align ul li{
-			margin: 0px;
-		}
+.wrapper.cta > .inner.inner-split > * {
+	max-width: 50%;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3821,7 +3821,7 @@
 
 		100% {
 			top: 0;
-			opacity: 1;:
+			opacity: 1;
 		}
 	}
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1402,7 +1402,7 @@
 	@media screen and (max-width: 480px) {
 
 		html, body {
-			min-width: 480px;
+			min-width: 480px; /* Not supporting any smaller width due to image scaling issues */
 		}
 
 	}
@@ -3642,12 +3642,10 @@
 				.wrapper.cta > .inner > * {
 					padding-left: 1.5em;
 					-ms-flex: auto;
-					/*width: 50%;*/
 				}
 
 				.wrapper.cta > .inner > :first-child {
 					padding-left: 0;
-					/*width: 50%;*/
 				}
 
 			body.is-mobile .wrapper.cta {
@@ -3823,7 +3821,7 @@
 
 		100% {
 			top: 0;
-			opacity: 1;
+			opacity: 1;:
 		}
 	}
 
@@ -4745,8 +4743,9 @@ ul.sponsors{
 
 /*-----TEAM ROSTER-----*/
 
-.team-lead{
-	display:flex;
+ul.team-lead {
+	flex: 0 0 auto;
+	display: flex;
 }
 
 .team-lead li{
@@ -4844,11 +4843,6 @@ ul.sponsors{
 
 .wrapper.cta > .inner > :first-child {
 	flex: 1 1 auto;
-}
-
-.wrapper.cta > .inner > ul.team-lead {
-	flex: 0 0 auto;
-	display: flex;
 }
 
 .wrapper.cta > .inner.inner-split > * {

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
 
 	<!-- Two -->
 	<section id="two" class="wrapper cta">
-		<div class="inner">
+		<div class="inner inner-split">
 			<header>
 				<h2>
 					Our Competition

--- a/roster.html
+++ b/roster.html
@@ -56,16 +56,16 @@
             </header>
             <ul class="list-inline team-lead">
                 <li>
-                    <img src="images/roster/vincent_yuan.jpg" alt="Vincent Yuan" />
-                    <h4>Vincent Yuan</h4>
-                    <p>Co-Captain & Tech Advisor</p>
-                    <a href="https://github.com/Dulluhan"><span class="fa fa-github fa-2x"> </span></a>
-                </li>
-                <li>
                     <img src="images/roster/valerian_ratu.jpg" alt="Valerian Ratu" />
                     <h4>Valerian Ratu</h4>
                     <p>Captain & Software Lead</p>
                     <a href="https://github.com/Valrat"><span class="fa fa-github fa-2x"> </span></a>
+                </li>
+                <li>
+                    <img src="images/roster/vincent_yuan.jpg" alt="Vincent Yuan" />
+                    <h4>Vincent Yuan</h4>
+                    <p>Co-Captain & Tech Advisor</p>
+                    <a href="https://github.com/Dulluhan"><span class="fa fa-github fa-2x"> </span></a>
                 </li>
             </ul>
         </div>
@@ -100,13 +100,13 @@
             </header>
             <ul class="list-inline team-lead">
                 <li>
-                    <img src="images/roster/sherry_wang.jpg" alt="Sherry Wang" />
-                    <h4>Sherry Wang</h4>
+                    <img src="images/roster/emma_park.jpg" alt="Emma Park" />
+                    <h4>Emma Park</h4>
                     <p>Mechanical Lead</p>
                 </li>
                 <li>
-                    <img src="images/roster/emma_park.jpg" alt="Emma Park" />
-                    <h4>Emma Park</h4>
+                    <img src="images/roster/sherry_wang.jpg" alt="Sherry Wang" />
+                    <h4>Sherry Wang</h4>
                     <p>Mechanical Lead</p>
                 </li>
             </ul>
@@ -272,36 +272,43 @@
     <section id="robots" class="wrapper cta darkblue-cta">
         <img class="cta-logo" src="images/car.png">
         <div class="inner">
-            <div class="inner-col-align">
-                <header class="major">
-                    <h2>Our Robots</h2>
-                    <p>
-                        These are our significant others on Saturdays.
-                    </p>
-                </header>
-                <ul class="list-inline team-lead">
-                    <li>
-                        <img src="images/roster/avalanche.jpg" alt="Avalanche" />
-                        <h4>Avalanche</h4>
-                        <p>Deceased Grandfather</p>
-                    </li>
-                    <li>
-                        <img src="images/roster/elsa.jpg" alt="Elsa" />
-                        <h4>Elsa</h4>
-                        <p>Resident Mom</p>
-                    </li>
-                    <li>
-                        <img src="images/roster/jack.jpg" alt="Jack" />
-                        <h4>Jack</h4>
-                        <p>Runaway Teen</p>
-                    </li>
-                    <li>
-                        <img src="images/roster/olaf.jpg" alt="Olaf" />
-                        <h4>Olaf</h4>
-                        <p>The Youngest</p>
-                    </li>
-                </ul>
-            </div>
+            <header class="major">
+                <h2>Our Star Robots</h2>
+                <p>
+                    These are our significant others on Saturdays.
+                </p>
+            </header>
+            <ul class="list-inline team-lead">
+                <li>
+                    <img src="images/roster/jack.jpg" alt="Jack" />
+                    <h4>Jack</h4>
+                    <p>Runaway Teen</p>
+                </li>
+                <li>
+                    <img src="images/roster/olaf.jpg" alt="Olaf" />
+                    <h4>Olaf</h4>
+                    <p>The Youngest</p>
+                </li>
+            </ul>
+        </div>
+    </section>
+    <section id="legacy-robots" class="wrapper">
+        <div class="inner">
+            <header class="align-center">
+                <h2>Legacy Robots</h2>
+            </header>
+            <ul class="list-inline team-member">
+                <li>
+                    <img src="images/roster/avalanche.jpg" alt="Avalanche" />
+                    <h4>Avalanche</h4>
+                    <p>Deceased Grandfather</p>
+                </li>
+                <li>
+                    <img src="images/roster/elsa.jpg" alt="Elsa" />
+                    <h4>Elsa</h4>
+                    <p>Resident Mom</p>
+                </li>
+            </ul>
         </div>
     </section>
 


### PR DESCRIPTION
## Resolve #35 

- Reduced highlight banner for robots to 2 entries, overflow moved into "legacy robot" section
- Assigned minimum width of 480px to temporarily avoid image scaling issues on smaller viewports
- Created .inner-split class to allow the homepage competition highlight to have a 50/50 screen-share space under the new flex rules in a highlight banner component
- Reordered team leads to accurately reflect the order it displays on the rendered webpage
- Change highlight banner to a new flex rule that pushes subsequent content down if it cannot fit on the same line anymore without overflowing **_(see below)_**

### Previously:
![old](https://user-images.githubusercontent.com/2358577/34707749-fcbd83a2-f4c3-11e7-8259-09407b2c928f.png)

### New: (same viewport width)
![new1](https://user-images.githubusercontent.com/2358577/34707759-032e86d2-f4c4-11e7-82a5-65652ad319b1.png)

### New (even smaller viewport width)
![new2](https://user-images.githubusercontent.com/2358577/34707769-10911a24-f4c4-11e7-9969-0e099be08e7c.png)
