### PR TITLE
Switch from old interview process to usage of application form

### DIFF
--- a/join.html
+++ b/join.html
@@ -82,13 +82,13 @@
                     <br/>
                     A smaller recruiting session is opened on January - geared towards experienced members who can learn quick and provide immediate contributions.
 
-                    <br/><br/> All students interested in joining Snowbots are required to attend an interview.
+                    <br/><br/> All students interested in joining Snowbots are required to complete an application form.
 					<!--, in addition
                     those interested in joining the software team are also required to do the <a href="challenge.html">software challenge.</a>-->
-                    Schedule an interview by emailing us and we will arrange an interview time for you.
+                    You can access the application form by clicking the link below.
 
                     <ul class="actions">
-                        <li><a href="mailto:snowbots.ubc@gmail.com" class="button big">Email us</a></li>
+                        <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSerfIB3gYCHNrUX8CnZJ40KKCPdKv6DmLHtU6km2oNLBXhbMQ/viewform" class="button big">Apply to Snowbots</a></li>
                     </ul>
                 </p>
             </header>


### PR DESCRIPTION
Remove reference to emailing Snowbots in the joining page and indicate proper means of applying.